### PR TITLE
Implement Assign operators for Quantities

### DIFF
--- a/qty-macros/src/lib.rs
+++ b/qty-macros/src/lib.rs
@@ -13,10 +13,10 @@ mod quantity_attr_helper;
 
 use ::convert_case::{Case, Casing};
 use ::proc_macro::TokenStream;
-use ::proc_macro2::{Span, TokenStream as TokenStream2};
 use ::proc_macro_error2::proc_macro_error;
+use ::proc_macro2::{Span, TokenStream as TokenStream2};
 use ::quote::quote;
-use ::syn::{parse_macro_input, Ident, ItemEnum};
+use ::syn::{Ident, ItemEnum, parse_macro_input};
 
 use crate::quantity_attr_helper::{analyze, codegen, parse_args, parse_item};
 
@@ -194,8 +194,7 @@ pub fn derive_enum_iter(input: TokenStream) -> TokenStream {
 /// * The given struct does have generic parameters and/or fields.
 /// * More than one attribute `#[ref_unit]` is given.
 /// * No attribute `#[unit]` is given.
-/// * Wrong number or wrong type of arguments given to attribute
-///   `#[ref_unit]`.
+/// * Wrong number or wrong type of arguments given to attribute `#[ref_unit]`.
 /// * Wrong number of arguments given to an attribute `#[unit]`.
 /// * No \<scale\> argument given to an attribute `#[unit]` when required.
 ///
@@ -335,11 +334,23 @@ pub fn derive_enum_iter(input: TokenStream) -> TokenStream {
 ///         <Self as HasRefUnit>::add(self, rhs)
 ///     }
 /// }
+/// impl AddAssign<Self> for Mass {
+///     #[inline(always)]
+///     fn add_assign(&mut self, rhs: Self) {
+///         <Self as HasRefUnit>::add_assign(self, rhs);
+///     }
+/// }
 /// impl Sub<Self> for Mass {
 ///     type Output = Self;
 ///     #[inline(always)]
 ///     fn sub(self, rhs: Self) -> Self::Output {
 ///         <Self as HasRefUnit>::sub(self, rhs)
+///     }
+/// }
+/// impl SubAssign<Self> for Mass {
+///     #[inline(always)]
+///     fn sub_assign(&mut self, rhs: Self) {
+///         <Self as HasRefUnit>::sub_assign(self, rhs);
 ///     }
 /// }
 /// impl Div<Self> for Mass {
@@ -401,11 +412,39 @@ pub fn derive_enum_iter(input: TokenStream) -> TokenStream {
 ///         Self::Output::new(self.amount() * rhs, self.unit())
 ///     }
 /// }
+/// impl MulAssign<AmountT> for Mass {
+///     #[inline(always)]
+///     fn mul_assign(&mut self, rhs: AmountT) {
+///         *self = *self * rhs;
+///     }
+/// }
 /// impl Div<AmountT> for Mass {
 ///     type Output = Self;
 ///     #[inline(always)]
 ///     fn div(self, rhs: AmountT) -> Self::Output {
 ///         Self::Output::new(self.amount() / rhs, self.unit())
+///     }
+/// }
+/// impl DivAssign<AmountT> for Mass {
+///     #[inline(always)]
+///     fn div_assign(&mut self, rhs: AmountT) {
+///         *self = *self / rhs;
+///     }
+/// }
+/// impl<TQ: Quantity> Mul<Rate<TQ, Self>> for Mass {
+///     type Output = TQ;
+///     fn mul(self, rhs: Rate<TQ, Self>) -> Self::Output {
+///         let amnt: AmountT = (self / rhs.per_unit().as_qty())
+///             / rhs.per_unit_multiple();
+///         Self::Output::new(amnt * rhs.term_amount(), rhs.term_unit())
+///     }
+/// }
+/// impl<PQ: Quantity> Div<Rate<Self, PQ>> for Mass {
+///     type Output = PQ;
+///     fn div(self, rhs: Rate<Self, PQ>) -> Self::Output {
+///         let amnt: AmountT = (self / rhs.term_unit().as_qty())
+///             / rhs.term_amount();
+///         Self::Output::new(amnt * rhs.per_unit_multiple(), rhs.per_unit())
 ///     }
 /// }
 /// ```

--- a/qty-macros/src/quantity_attr_helper.rs
+++ b/qty-macros/src/quantity_attr_helper.rs
@@ -485,11 +485,23 @@ fn codegen_qty_single_unit(
                 Self::new(self.amount() + rhs.amount(), self.unit())
             }
         }
+        impl AddAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn add_assign(&mut self, rhs: Self) {
+                *self = *self + rhs;
+            }
+        }
         impl Sub<Self> for #qty_ident {
             type Output = Self;
             #[inline(always)]
             fn sub(self, rhs: Self) -> Self::Output {
                 Self::new(self.amount() - rhs.amount(), self.unit())
+            }
+        }
+        impl SubAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn sub_assign(&mut self, rhs: Self) {
+                *self = *self - rhs;
             }
         }
         impl Div<Self> for #qty_ident {
@@ -684,11 +696,23 @@ fn codegen_qty_without_ref_unit(
                 <Self as Quantity>::add(self, rhs)
             }
         }
+        impl AddAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn add_assign(&mut self, rhs: Self) {
+                <Self as Quantity>::add_assign(self, rhs);
+            }
+        }
         impl Sub<Self> for #qty_ident {
             type Output = Self;
             #[inline(always)]
             fn sub(self, rhs: Self) -> Self::Output {
                 <Self as Quantity>::sub(self, rhs)
+            }
+        }
+        impl SubAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn sub_assign(&mut self, rhs: Self) {
+                <Self as Quantity>::sub_assign(self, rhs);
             }
         }
         impl Div<Self> for #qty_ident {
@@ -821,11 +845,23 @@ fn codegen_qty_with_ref_unit(
                 <Self as HasRefUnit>::add(self, rhs)
             }
         }
+        impl AddAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn add_assign(&mut self, rhs: Self) {
+                <Self as HasRefUnit>::add_assign(self, rhs);
+            }
+        }
         impl Sub<Self> for #qty_ident {
             type Output = Self;
             #[inline(always)]
             fn sub(self, rhs: Self) -> Self::Output {
                 <Self as HasRefUnit>::sub(self, rhs)
+            }
+        }
+        impl SubAssign<Self> for #qty_ident {
+            #[inline(always)]
+            fn sub_assign(&mut self, rhs: Self) {
+                <Self as HasRefUnit>::sub_assign(self, rhs);
             }
         }
         impl Div<Self> for #qty_ident {
@@ -867,11 +903,23 @@ fn codegen_impl_std_traits(qty_ident: &syn::Ident) -> TokenStream {
                 Self::Output::new(self.amount() * rhs, self.unit())
             }
         }
+        impl MulAssign<AmountT> for #qty_ident {
+            #[inline(always)]
+            fn mul_assign(&mut self, rhs: AmountT) {
+                *self = *self * rhs;
+            }
+        }
         impl Div<AmountT> for #qty_ident {
             type Output = Self;
             #[inline(always)]
             fn div(self, rhs: AmountT) -> Self::Output {
                 Self::Output::new(self.amount() / rhs, self.unit())
+            }
+        }
+        impl DivAssign<AmountT> for #qty_ident {
+            #[inline(always)]
+            fn div_assign(&mut self, rhs: AmountT) {
+                *self = *self / rhs;
             }
         }
         impl<TQ: Quantity> Mul<Rate<TQ, Self>> for #qty_ident {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ use core::{
 };
 
 #[cfg(feature = "fpdec")]
-pub use amnt_dec::{AmountT, Dec, Decimal, AMNT_ONE, AMNT_ZERO};
+pub use amnt_dec::{AMNT_ONE, AMNT_ZERO, AmountT, Dec, Decimal};
 #[cfg(all(
     not(feature = "fpdec"),
     any(
@@ -77,7 +77,7 @@ pub use amnt_dec::{AmountT, Dec, Decimal, AMNT_ONE, AMNT_ZERO};
         )
     )
 ))]
-pub use amnt_f32::{AmountT, AMNT_ONE, AMNT_ZERO};
+pub use amnt_f32::{AMNT_ONE, AMNT_ZERO, AmountT};
 #[cfg(all(
     not(feature = "fpdec"),
     any(
@@ -90,7 +90,7 @@ pub use amnt_f32::{AmountT, AMNT_ONE, AMNT_ZERO};
         )
     )
 ))]
-pub use amnt_f64::{AmountT, AMNT_ONE, AMNT_ZERO};
+pub use amnt_f64::{AMNT_ONE, AMNT_ZERO, AmountT};
 pub use converter::{ConversionTable, Converter};
 pub use rate::Rate;
 pub use si_prefixes::SIPrefix;
@@ -298,15 +298,7 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
     ///
     /// Panics if `self` and `other` have different units.
     fn add_assign(&mut self, rhs: Self) {
-        if self.unit() == rhs.unit() {
-            *self = self.add(rhs);
-        } else {
-            panic!(
-                "Can't add '{}' and '{}'.",
-                self.unit().symbol(),
-                rhs.unit().symbol()
-            )
-        }
+        *self = self.add(rhs);
     }
 
     /// Returns the difference between `self` and `other`, if both have the
@@ -333,15 +325,7 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
     ///
     /// Panics if `self` and `other` have different units.
     fn sub_assign(&mut self, rhs: Self) {
-        if self.unit() == rhs.unit() {
-            *self = self.sub(rhs);
-        } else {
-            panic!(
-                "Can't add '{}' and '{}'.",
-                self.unit().symbol(),
-                rhs.unit().symbol()
-            )
-        }
+        *self = self.sub(rhs);
     }
 
     /// Returns the quotient `self` / `other`, if both have the same unit.
@@ -485,8 +469,8 @@ where
     #[must_use]
     fn _fit(amount: AmountT) -> Self {
         let take_all = Self::REF_UNIT.si_prefix().is_none();
-        let mut it = Self::iter_units()
-            .filter(|u| take_all || u.si_prefix().is_some());
+        let mut it =
+            Self::iter_units().filter(|u| take_all || u.si_prefix().is_some());
         // `it` returns atleast the reference unit, so its safe to unwrap here
         let first = it.next().unwrap();
         let last = it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,24 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
         );
     }
 
+    /// Adds the amount of `other` to `self` in place, if both have the same
+    /// unit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` and `other` have different units.
+    fn add_assign(&mut self, rhs: Self) {
+        if self.unit() == rhs.unit() {
+            *self = self.add(rhs);
+        } else {
+            panic!(
+                "Can't add '{}' and '{}'.",
+                self.unit().symbol(),
+                rhs.unit().symbol()
+            )
+        }
+    }
+
     /// Returns the difference between `self` and `other`, if both have the
     /// same unit.
     ///
@@ -306,6 +324,24 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
             self.unit().symbol(),
             rhs.unit().symbol(),
         );
+    }
+
+    /// Subtracts the amount of `other` from `self` in place, if both have the
+    /// same unit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` and `other` have different units.
+    fn sub_assign(&mut self, rhs: Self) {
+        if self.unit() == rhs.unit() {
+            *self = self.sub(rhs);
+        } else {
+            panic!(
+                "Can't add '{}' and '{}'.",
+                self.unit().symbol(),
+                rhs.unit().symbol()
+            )
+        }
     }
 
     /// Returns the quotient `self` / `other`, if both have the same unit.
@@ -384,6 +420,11 @@ where
         Self::new(self.equiv_amount(to_unit), to_unit)
     }
 
+    /// Converts `self` to the equivalent `to_unit`.
+    fn convert_assign(&mut self, to_unit: Self::UnitType) {
+        *self = self.convert(to_unit);
+    }
+
     /// Returns true, if `self` and `other` have equivalent amounts, otherwise
     /// `false`.
     #[inline(always)]
@@ -410,10 +451,22 @@ where
         Self::new(self.amount() + rhs.equiv_amount(self.unit()), self.unit())
     }
 
+    /// Adds the unit-equivalent amount of `other` to `self` in place.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = HasRefUnit::add(*self, rhs);
+    }
+
     /// Returns the difference between `self` and `other`
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         Self::new(self.amount() - rhs.equiv_amount(self.unit()), self.unit())
+    }
+
+    /// Subtracts the unit-equivalent amount of `other` from `self` in place.
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = HasRefUnit::sub(*self, rhs);
     }
 
     /// Returns the quotient `self` / `other`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@ pub use core::cmp::Ordering;
 #[doc(hidden)]
 pub use core::fmt;
 #[doc(hidden)]
-pub use core::ops::{Add, Div, Mul, Neg, Sub};
+pub use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use qty_macros::quantity;
 

--- a/tests/test_qty.rs
+++ b/tests/test_qty.rs
@@ -189,6 +189,17 @@ mod quantity_with_ref_unit_tests {
     }
 
     #[test]
+    fn test_convert_assign() {
+        let mut qty = Foo::new(Amnt!(17.4), FooUnit::B);
+        qty.convert_assign(FooUnit::A);
+        assert_almost_eq!(qty.amount(), Amnt!(6.96));
+        assert_eq!(qty.unit(), FooUnit::A);
+        qty.convert_assign(FooUnit::B);
+        assert_almost_eq!(qty.amount(), Amnt!(17.4));
+        assert_eq!(qty.unit(), FooUnit::B);
+    }
+
+    #[test]
     fn test_cmp_same_unit() {
         let qty1 = Amnt!(17.4) * FooUnit::A;
         let qty2 = Amnt!(0.37) * FooUnit::A;
@@ -250,6 +261,18 @@ mod quantity_with_ref_unit_tests {
     }
 
     #[test]
+    fn test_add_assign_same_unit() {
+        let amnt1 = Amnt!(0.1);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(-0.2);
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit1;
+        qty1 += qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 + amnt2);
+        assert_eq!(qty1.unit(), unit1);
+    }
+
+    #[test]
     fn test_add_diff_unit() {
         let amnt1 = Amnt!(17.4);
         let unit1 = FooUnit::A;
@@ -263,6 +286,19 @@ mod quantity_with_ref_unit_tests {
         let res = qty2 + qty1;
         assert_almost_eq!(res.amount(), amnt1 * Amnt!(2.5) + amnt2);
         assert_eq!(res.unit(), unit2);
+    }
+
+    #[test]
+    fn test_add_assign_diff_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let unit2 = FooUnit::B;
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit2;
+        qty1 += qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 + amnt2 * Amnt!(0.4));
+        assert_eq!(qty1.unit(), unit1);
     }
 
     #[test]
@@ -281,6 +317,18 @@ mod quantity_with_ref_unit_tests {
     }
 
     #[test]
+    fn test_sub_assign_same_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit1;
+        qty1 -= qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 - amnt2);
+        assert_eq!(qty1.unit(), unit1);
+    }
+
+    #[test]
     fn test_sub_diff_unit() {
         let amnt1 = Amnt!(17.4);
         let unit1 = FooUnit::A;
@@ -294,6 +342,19 @@ mod quantity_with_ref_unit_tests {
         let res = qty2 - qty1;
         assert_almost_eq!(res.amount(), amnt2 - amnt1 * Amnt!(2.5));
         assert_eq!(res.unit(), unit2);
+    }
+
+    #[test]
+    fn test_sub_assign_diff_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.3);
+        let unit2 = FooUnit::B;
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit2;
+        qty1 -= qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 - amnt2 * Amnt!(0.4));
+        assert_eq!(qty1.unit(), unit1);
     }
 
     #[test]
@@ -336,6 +397,17 @@ mod quantity_with_ref_unit_tests {
     }
 
     #[test]
+    fn test_mul_assign_amnt() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let mut qty1 = amnt1 * unit1;
+        qty1 *= amnt2;
+        assert_almost_eq!(qty1.amount(), amnt1 * amnt2);
+        assert_eq!(qty1.unit(), qty1.unit());
+    }
+
+    #[test]
     fn test_div_amnt() {
         let amnt1 = Amnt!(15.54);
         let unit1 = FooUnit::A;
@@ -344,6 +416,17 @@ mod quantity_with_ref_unit_tests {
         let res = qty1 / amnt2;
         assert_almost_eq!(res.amount(), amnt1 / amnt2);
         assert_eq!(res.unit(), qty1.unit());
+    }
+
+    #[test]
+    fn test_div_assign_amnt() {
+        let amnt1 = Amnt!(15.54);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(3.7);
+        let mut qty1 = amnt1 * unit1;
+        qty1 /= amnt2;
+        assert_almost_eq!(qty1.amount(), amnt1 / amnt2);
+        assert_eq!(qty1.unit(), unit1);
     }
 }
 
@@ -457,6 +540,18 @@ mod quantity_without_ref_unit_tests {
     }
 
     #[test]
+    fn test_add_assign_same_unit() {
+        let amnt1 = Amnt!(5000.17);
+        let unit1 = FooUnit::C;
+        let amnt2 = Amnt!(-2);
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit1;
+        qty1 += qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 + amnt2);
+        assert_eq!(qty1.unit(), unit1);
+    }
+
+    #[test]
     #[should_panic]
     fn test_add_diff_unit() {
         let amnt1 = Amnt!(17.4);
@@ -466,6 +561,18 @@ mod quantity_without_ref_unit_tests {
         let qty1 = amnt1 * unit1;
         let qty2 = amnt2 * unit2;
         let _res = qty1 + qty2;
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_add_assign_diff_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let unit2 = FooUnit::B;
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit2;
+        qty1 += qty2;
     }
 
     #[test]
@@ -484,6 +591,18 @@ mod quantity_without_ref_unit_tests {
     }
 
     #[test]
+    fn test_sub_assign_same_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit1;
+        qty1 -= qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 - amnt2);
+        assert_eq!(qty1.unit(), unit1);
+    }
+
+    #[test]
     #[should_panic]
     fn test_sub_diff_unit() {
         let amnt1 = Amnt!(17.4);
@@ -493,6 +612,18 @@ mod quantity_without_ref_unit_tests {
         let qty1 = amnt1 * unit1;
         let qty2 = amnt2 * unit2;
         let _res = qty1 - qty2;
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sub_assign_diff_unit() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = FooUnit::A;
+        let amnt2 = Amnt!(0.3);
+        let unit2 = FooUnit::B;
+        let mut qty1 = amnt1 * unit1;
+        let qty2 = amnt2 * unit2;
+        qty1 -= qty2;
     }
 
     #[test]
@@ -516,6 +647,53 @@ mod quantity_without_ref_unit_tests {
         let qty1 = amnt1 * unit1;
         let qty2 = amnt2 * unit2;
         let _res = qty1 / qty2;
+    }
+
+    #[test]
+    fn test_mul_amnt() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = crate::quantity_with_ref_unit_tests::FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let qty1 = amnt1 * unit1;
+        let res = qty1 * amnt2;
+        assert_almost_eq!(res.amount(), amnt1 * amnt2);
+        assert_eq!(res.unit(), qty1.unit());
+        let res = amnt2 * qty1;
+        assert_almost_eq!(res.amount(), amnt1 * amnt2);
+        assert_eq!(res.unit(), qty1.unit());
+    }
+
+    #[test]
+    fn test_mul_assign_amnt() {
+        let amnt1 = Amnt!(17.4);
+        let unit1 = crate::quantity_with_ref_unit_tests::FooUnit::A;
+        let amnt2 = Amnt!(0.37);
+        let mut qty1 = amnt1 * unit1;
+        qty1 *= amnt2;
+        assert_almost_eq!(qty1.amount(), amnt1 * amnt2);
+        assert_eq!(qty1.unit(), qty1.unit());
+    }
+
+    #[test]
+    fn test_div_amnt() {
+        let amnt1 = Amnt!(15.54);
+        let unit1 = crate::quantity_with_ref_unit_tests::FooUnit::A;
+        let amnt2 = Amnt!(3.7);
+        let qty1 = amnt1 * unit1;
+        let res = qty1 / amnt2;
+        assert_almost_eq!(res.amount(), amnt1 / amnt2);
+        assert_eq!(res.unit(), qty1.unit());
+    }
+
+    #[test]
+    fn test_div_assign_amnt() {
+        let amnt1 = Amnt!(15.54);
+        let unit1 = crate::quantity_with_ref_unit_tests::FooUnit::A;
+        let amnt2 = Amnt!(3.7);
+        let mut qty1 = amnt1 * unit1;
+        qty1 /= amnt2;
+        assert_almost_eq!(qty1.amount(), amnt1 / amnt2);
+        assert_eq!(qty1.unit(), unit1);
     }
 }
 
@@ -586,6 +764,17 @@ mod quantity_single_unit_tests {
     }
 
     #[test]
+    fn test_add_assign() {
+        let amnt1 = Amnt!(517.04);
+        let amnt2 = Amnt!(14.3);
+        let mut qty1 = amnt1 * POP;
+        let qty2 = amnt2 * POP;
+        qty1 += qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 + amnt2);
+        assert_eq!(qty1.unit(), POP);
+    }
+
+    #[test]
     fn test_sub() {
         let amnt1 = Amnt!(14.3);
         let amnt2 = Amnt!(517.04);
@@ -597,6 +786,17 @@ mod quantity_single_unit_tests {
         let res = qty2 - qty1;
         assert_almost_eq!(res.amount(), amnt2 - amnt1);
         assert_eq!(res.unit(), POP);
+    }
+
+    #[test]
+    fn test_sub_assign() {
+        let amnt1 = Amnt!(14.3);
+        let amnt2 = Amnt!(517.04);
+        let mut qty1 = amnt1 * POP;
+        let qty2 = amnt2 * POP;
+        qty1 -= qty2;
+        assert_almost_eq!(qty1.amount(), amnt1 - amnt2);
+        assert_eq!(qty1.unit(), POP);
     }
 
     #[test]


### PR DESCRIPTION
I've started to use quantities as properties on some larger structs where it would be nice to be able to modify them in place (for operations which result in the same Quantity struct). It took me some thinking to find a way to implement these traits that aligns with how you handle the regular math operators, but I think I found a solution that I'm happy with.

Additionally, I've added a `convert_assign` function to `HasRefUnit` for if an external user would like to do a `convert` in place.