### PR TITLE
Move abs and signum from base quantity impl into the Quantity trait

### DIFF
--- a/qty-macros/src/quantity_attr_helper.rs
+++ b/qty-macros/src/quantity_attr_helper.rs
@@ -449,14 +449,6 @@ fn codegen_qty_single_unit(
         pub struct #qty_ident {
             amount: AmountT
         }
-        impl #qty_ident {
-            fn abs(&self) -> Self {
-                Self { amount: self.amount.abs() }
-            }
-            fn signum(&self) -> AmountT {
-                self.amount.signum()
-            }
-        }
         impl Quantity for #qty_ident {
             type UnitType = #unit_enum_ident;
 
@@ -610,10 +602,6 @@ fn codegen_impl_quantity(
     unit_enum_ident: &syn::Ident,
 ) -> TokenStream {
     let serde_derives = codegen_serde_derives();
-    let fn_abs_doc =
-        format!("Returns the absolute value of the `{}` value.", qty_ident);
-    let fn_signum_doc =
-        format!("Returns the sign of the `{}` values amount.", qty_ident);
     let fn_new_doc = format!(
         "Creates a new `{}` value with the given amount and unit.",
         qty_ident
@@ -628,16 +616,6 @@ fn codegen_impl_quantity(
         pub struct #qty_ident {
             amount: AmountT,
             unit: #unit_enum_ident
-        }
-        impl #qty_ident {
-            #[doc = #fn_abs_doc]
-            pub fn abs(&self) -> Self {
-                Self { amount: self.amount.abs(), unit: self.unit }
-            }
-            #[doc = #fn_signum_doc]
-            pub fn signum(&self) -> AmountT {
-                self.amount.signum()
-            }
         }
         impl Quantity for #qty_ident {
             type UnitType = #unit_enum_ident;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,18 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
     /// Returns the unit of `self`.
     fn unit(&self) -> Self::UnitType;
 
+    /// Returns the absolute value of `self`.
+    #[inline(always)]
+    fn abs(&self) -> Self {
+        Self::new(self.amount().abs(), self.unit())
+    }
+
+    /// Returns the sign number of `self`.
+    #[inline(always)]
+    fn signum(&self) -> AmountT {
+        self.amount().signum()
+    }
+
     /// Return `true` if `self` and `other` have the same unit and their
     /// amounts are equal, otherwise `false`.
     #[inline(always)]
@@ -354,21 +366,13 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
         if self.unit().symbol().is_empty() {
             fmt::Display::fmt(&self.amount(), form)
         } else {
-            let tmp: String;
             let amnt_non_neg = self.amount() >= AMNT_ZERO;
-            #[cfg(feature = "fpdec")]
             let abs_amnt = self.amount().abs();
-            #[cfg(not(feature = "fpdec"))]
-            let abs_amnt = if amnt_non_neg {
-                self.amount()
+            let tmp = if let Some(prec) = form.precision() {
+                format!("{:.*} {}", prec, abs_amnt, self.unit())
             } else {
-                -self.amount()
+                format!("{} {}", abs_amnt, self.unit())
             };
-            if let Some(prec) = form.precision() {
-                tmp = format!("{:.*} {}", prec, abs_amnt, self.unit());
-            } else {
-                tmp = format!("{} {}", abs_amnt, self.unit());
-            }
             form.pad_integral(amnt_non_neg, "", &tmp)
         }
     }


### PR DESCRIPTION
I've recently run into the need to use `abs` with a generic struct bounded by Quantity and realized my previous implementation of `abs` and `signum` don't allow for this. I recall at the time I had some concern about whether it could or should exist on the Quantity trait, but looking back at the code now I have no idea what my concerns were anymore and being able to access the functions from the Quantity trait should provide more flexibility.

In this PR I've moved the implementations of those functions into the Quantity trait so that they may be easily accessed by generics as necessary. I also noticed that `fmt` on quantity has some roundabout extra code for grabbing the absolute value amount which was no longer necessary after my previous implementation, so I've taken the liberty to simplify that function slightly as well. All tests remain passing.