### PR TITLE
Extend Quantity and HasRefUnit trait bounds to reduce boilerplate for generics

### DIFF
--- a/qty-macros/src/quantity_attr_helper.rs
+++ b/qty-macros/src/quantity_attr_helper.rs
@@ -475,6 +475,19 @@ fn codegen_qty_single_unit(
                 Self::UnitType::#unit_ident
             }
         }
+        impl Eq for #qty_ident {}
+        impl PartialEq<Self> for #qty_ident {
+            #[inline(always)]
+            fn eq(&self, other: &Self) -> bool {
+                <Self as Quantity>::eq(self, other)
+            }
+        }
+        impl PartialOrd for #qty_ident {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                <Self as Quantity>::partial_cmp(self, other)
+            }
+        }
         impl Add<Self> for #qty_ident {
             type Output = Self;
             #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,9 @@ pub trait LinearScaledUnit: Unit {
 }
 
 /// The abstract type of quantities.
-pub trait Quantity: Copy + Sized + Mul<AmountT, Output = Self> {
+pub trait Quantity:
+    Copy + PartialEq + PartialOrd + Sized + Mul<AmountT, Output = Self>
+{
     /// Associated type of unit
     type UnitType: Unit<QuantityType = Self>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub trait LinearScaledUnit: Unit {
 }
 
 /// The abstract type of quantities.
-pub trait Quantity: Copy + Sized + Mul<AmountT> {
+pub trait Quantity: Copy + Sized + Mul<AmountT, Output = Self> {
     /// Associated type of unit
     type UnitType: Unit<QuantityType = Self>;
 
@@ -375,9 +375,10 @@ pub trait Quantity: Copy + Sized + Mul<AmountT> {
 }
 
 /// Trait for quantities having a reference unit
-pub trait HasRefUnit: Quantity + Add<Self> + Sub<Self> + Div<Self>
-where
-    <Self as Quantity>::UnitType: LinearScaledUnit,
+pub trait HasRefUnit: Quantity<UnitType: LinearScaledUnit>
+    + Add<Self, Output = Self>
+    + Sub<Self, Output = Self>
+    + Div<Self, Output = AmountT>
 {
     /// Unit used as reference for scaling the units of `Self::UnitType`.
     const REF_UNIT: <Self as Quantity>::UnitType;


### PR DESCRIPTION
This is another simple change that I think would be beneficial from trying to use the Quantity or HasRefUnit traits as bounds on generics.

First, I've added Output type bounds on the math operators aligning with the implementations that get generated in the macro. This will let generics do basic math operations for a single type without extra specification.

Second, I've moved the LinearScaledUnit requirement of HasRefUnit from the where clause to a strict requirement of the implementation. I couldn't come up with a situation where you would want HasRefUnit without LinearScaledUnit implemented on the Unit type, so I don't believe the harder requirement should be an issue.

Third, I've included PartialEq and PartialOrd as a bound on Quantity. Single unit quantities did not already implement Eq, PartialEq, and PartialOrd like the others, but since the implementation details are already in Quantity I thought it would probably be fine to implement them as well. This one I added as a separate commit so it could be popped off easily if for some reason this isn't desirable. I had briefly attempted to also add Eq as a bound, but even though the macro does implement Eq alongside PartialEq, the compiler wasn't very happy about it with AmountT being aliased to f32 or f64.

Aside from the caveat on PartialEq/PartialOrd, all of these new requirements were already enforced in the generation macro.